### PR TITLE
Add 'co.paralleluniverse.fibers.disableAgentWarning' system property

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -74,6 +74,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
     private static final boolean verifyInstrumentation = Boolean.parseBoolean(System.getProperty("co.paralleluniverse.fibers.verifyInstrumentation", "false"));
     private static final ClassContext classContext = verifyInstrumentation ? new ClassContext() : null;
     private static final boolean traceInterrupt = Boolean.parseBoolean(System.getProperty("co.paralleluniverse.fibers.traceInterrupt", "false"));
+    private static final boolean disableAgentWarning = Boolean.parseBoolean(System.getProperty("co.paralleluniverse.fibers.disableAgentWarning", "false"));
     public static final int DEFAULT_STACK_SIZE = 32;
     private static final Object SERIALIZER_BLOCKER = new Object();
     private static final boolean MAINTAIN_ACCESS_CONTROL_CONTEXT = (System.getSecurityManager() != null);
@@ -87,7 +88,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
             System.err.println("QUASAR WARNING: Debug mode enabled. This may harm performance.");
         if (Debug.isAssertionsEnabled())
             System.err.println("QUASAR WARNING: Assertions enabled. This may harm performance.");
-        if (!SuspendableHelper.isJavaAgentActive())
+        if (!SuspendableHelper.isJavaAgentActive() && !disableAgentWarning)
             System.err.println("QUASAR WARNING: Quasar Java Agent isn't running. If you're using another instrumentation method you can ignore this message; "
                     + "otherwise, please refer to the Getting Started section in the Quasar documentation.");
         assert printVerifyInstrumentationWarning();


### PR DESCRIPTION
Using Quasar with AOT instrumentation (i.e. pre-processing classes with the InstrumentationTask Ant task and not using the Quasar Java Agent) causes the following warning to be displayed at startup:

```
QUASAR WARNING: Quasar Java Agent isn't running. If you're using another instrumentation method you can ignore this message; otherwise, please refer to the Getting Started section in the Quasar documentation.
```

There doesn't seem to be a way to disable the warning, so I added a system property (co.paralleluniverse.fibers.disableAgentWarning) that when true causes Quasar to suppress it.

In our particular use case, it's desirable to be able to set this at runtime (e.g. from main), like so:

```
System.setProperty("co.paralleluniverse.fibers.disableAgentWarning", "true");
```

Is there a better way to do this than using a system property? (Adding a system property seemed to be a simple enough route, but perhaps there's a more elegant solution)
