### PR TITLE
Added else statements to Strand.printStackTrace

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/strands/Strand.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/Strand.java
@@ -874,7 +874,7 @@ public abstract class Strand {
     public static void printStackTrace(StackTraceElement[] trace, java.io.PrintStream out) {
         if (trace == null)
             out.println("No stack trace");
-        for (StackTraceElement traceElement : trace)
+        else for (StackTraceElement traceElement : trace)
             out.println("\tat " + traceElement);
     }
 
@@ -887,7 +887,7 @@ public abstract class Strand {
     public static void printStackTrace(StackTraceElement[] trace, java.io.PrintWriter out) {
         if (trace == null)
             out.println("No stack trace");
-        for (StackTraceElement traceElement : trace)
+        else for (StackTraceElement traceElement : trace)
             out.println("\tat " + traceElement);
     }
 


### PR DESCRIPTION
Prevents NullPointerException's when trace is null.

In reference to https://github.com/puniverse/quasar/issues/68
