### PR TITLE
tryGetActor always fails

### DIFF
--- a/quasar-galaxy/src/main/java/co/paralleluniverse/remote/galaxy/GlxGlobalRegistry.java
+++ b/quasar-galaxy/src/main/java/co/paralleluniverse/remote/galaxy/GlxGlobalRegistry.java
@@ -174,7 +174,7 @@ public class GlxGlobalRegistry implements ActorRegistry {
         final StoreTransaction txn = store.beginTransaction();
         try {
             try {
-                final long root = store.getRoot(rootName, null);
+                final long root = store.getRoot(rootName, txn);
                 byte[] buf = store.get(root);
                 if (buf == null) {
                     LOG.debug("Store returned null for root {}", rootName);


### PR DESCRIPTION
Actually I don't think the explanation is required here. But I found that error while was getting actor-ref by calling `co.paralleluniverse.actors.ActorRegistry#tryGetActor`. Stacktrace I've got is the following:

    java.lang.IllegalArgumentException: Transaction may not be null for this operation.
	    at co.paralleluniverse.galaxy.core.StoreImpl.verifyNonNull(StoreImpl.java:485)
	    at co.paralleluniverse.galaxy.core.StoreImpl.getRoot(StoreImpl.java:86)
	    at co.paralleluniverse.galaxy.quasar.StoreImpl.getRoot(StoreImpl.java:209)
	    at co.paralleluniverse.remote.galaxy.GlxGlobalRegistry.tryGetActor0(GlxGlobalRegistry.java:177)
	    at co.paralleluniverse.remote.galaxy.GlxGlobalRegistry.tryGetActor(GlxGlobalRegistry.java:138)
	    at co.paralleluniverse.actors.ActorRegistry.tryGetActor(ActorRegistry.java:71)