### PR TITLE
GlxGlobalRegistry should return null instead of throwing NPE

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/strands/Strand.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/Strand.java
@@ -1029,7 +1029,7 @@ public abstract class Strand {
         public void join(long timeout, TimeUnit unit) throws ExecutionException, InterruptedException, TimeoutException {
             long nanos = unit.toNanos(timeout);
             long millis = TimeUnit.MILLISECONDS.convert(nanos, TimeUnit.NANOSECONDS);
-            thread.join(millis, (int) (nanos - millis));
+            thread.join(millis, (int) (nanos - TimeUnit.MILLISECONDS.toNanos(millis)));
             if (thread.isAlive())
                 throw new TimeoutException();
         }

--- a/quasar-galaxy/src/main/java/co/paralleluniverse/remote/galaxy/GlxGlobalRegistry.java
+++ b/quasar-galaxy/src/main/java/co/paralleluniverse/remote/galaxy/GlxGlobalRegistry.java
@@ -153,7 +153,11 @@ public class GlxGlobalRegistry extends ActorRegistry {
         ActorRef<?> actor = tryCache(name);
         if (actor != null)
             return actor;
-        return updateCache(name, getActor0(name, timeout, unit));
+        final CacheEntry actorEntry = getActor0(name, timeout, unit);
+        if (actorEntry == null) {
+            return null;
+        }
+        return updateCache(name, actorEntry);
     }
 
     @Override


### PR DESCRIPTION
Because **updateCache** doesn't accept nullable values