### PR TITLE
[BUG] Some code changes for reproducing queue hangs up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -554,7 +554,7 @@ project (':quasar-core') {
         }
         tasks.withType(Test) {
             filter {
-                includeTestsMatching "*SingleConsumerLinkedArrayObjectQueueTest"
+                includeTestsMatching "*SingleConsumerLinked*ObjectQueueTest"
             }
         }
         run.dependsOn compileJdk8Java, jdk8testClasses

--- a/build.gradle
+++ b/build.gradle
@@ -552,6 +552,11 @@ project (':quasar-core') {
         tasks.withType(JavaExec) {
             classpath += sourceSets.jdk8test.runtimeClasspath + sourceSets.jdk8test.output
         }
+        tasks.withType(Test) {
+            filter {
+                includeTestsMatching "*SingleConsumerLinkedArrayObjectQueueTest"
+            }
+        }
         run.dependsOn compileJdk8Java, jdk8testClasses
     } else {
         tasks.withType(JavaExec) {

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayQueue.java
@@ -31,6 +31,7 @@ abstract class SingleConsumerLinkedArrayQueue<E> extends SingleConsumerQueue<E> 
     volatile Node tail;
     volatile int p016, p017, p018, p019, p020, p021, p022, p023, p024, p025, p026, p027, p028, p029, p030;
     int seed = (int) System.nanoTime();
+    protected static volatile int v = 0;
 
     @SuppressWarnings("OverridableMethodCallInConstructor")
     public SingleConsumerLinkedArrayQueue() {
@@ -64,6 +65,11 @@ abstract class SingleConsumerLinkedArrayQueue<E> extends SingleConsumerQueue<E> 
         boolean found = false;
         for (;;) {
             if (i >= blockSize) {
+                if (v == 0) {
+                    // PUT BREAKPOINT HERE
+                    v = 1;
+                }
+
                 if (tail == n)
                     return false;
 
@@ -86,7 +92,7 @@ abstract class SingleConsumerLinkedArrayQueue<E> extends SingleConsumerQueue<E> 
                 break;
             }
         }
-        orderedSetHead(n); // 
+        orderedSetHead(n); //
         headIndex = i;
         return found;
     }

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedQueue.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedQueue.java
@@ -28,6 +28,7 @@ abstract class SingleConsumerLinkedQueue<E> extends SingleConsumerQueue<E> {
     volatile Node head;
     volatile Object p001, p002, p003, p004, p005, p006, p007, p008, p009, p010, p011, p012, p013, p014, p015;
     volatile Node tail;
+    protected static volatile int v = 0;
 
     @SuppressWarnings("OverridableMethodCallInConstructor")
     public SingleConsumerLinkedQueue() {
@@ -88,6 +89,10 @@ abstract class SingleConsumerLinkedQueue<E> extends SingleConsumerQueue<E> {
                 if (tail == node && compareAndSetTail(node, null)) { // a concurrent enq would either cause this to fail and wait for node.next, or have this succeed and then set tail and head
                     node.next = null;
                     return;
+                }
+                if (v == 0) {
+                    // PUT BREAKPOINT HERE
+                    v = 1;
                 }
                 while ((h = node.next) == null);
             }

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayObjectQueueTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedArrayObjectQueueTest.java
@@ -1,0 +1,60 @@
+package co.paralleluniverse.strands.queues;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * SingleConsumerLinkedArrayObjectQueue hangs test.
+ */
+public class SingleConsumerLinkedArrayObjectQueueTest {
+    @Test
+    public void uglyTest() throws InterruptedException {
+        final AtomicBoolean done = new AtomicBoolean(false); // Done flag for thread shutdown
+        final AtomicInteger size = new AtomicInteger(); // Queue size
+        final AtomicLong progress = new AtomicLong(); // Processed iterations count
+        final SingleConsumerLinkedArrayObjectQueue<Object> queue = new SingleConsumerLinkedArrayObjectQueue<>(); // Tested queue
+        final Thread consumer = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                while (!done.get()) {
+                    if (queue.poll() != null) {
+                        size.decrementAndGet();
+                    }
+                    progress.incrementAndGet();
+                }
+            }
+        }, "consumer");
+        final Thread producer = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                while (!done.get()) {
+                    if (size.get() < 1) {
+                        queue.add(new Object());
+                        size.incrementAndGet();
+                    }
+                }
+            }
+        }, "producer");
+        // Start threads
+        consumer.setDaemon(true);
+        producer.setDaemon(true);
+        consumer.start();
+        producer.start();
+        // Run 10 seconds and print processed iterations
+        for (int i = 0; i < 100; ++i) {
+            Thread.sleep(100);
+            System.out.println(progress.get());
+        }
+        // Shutdown threads
+        done.set(true);
+        consumer.join(TimeUnit.SECONDS.toMillis(5));
+        producer.join(TimeUnit.SECONDS.toMillis(5));
+        Assert.assertFalse(consumer.isAlive());
+        Assert.assertFalse(producer.isAlive());
+    }
+}

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedObjectQueueTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/queues/SingleConsumerLinkedObjectQueueTest.java
@@ -11,17 +11,21 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * SingleConsumerLinkedArrayObjectQueue hangs test.
  */
-public class SingleConsumerLinkedArrayObjectQueueTest {
+public class SingleConsumerLinkedObjectQueueTest {
     @Test
     public void uglyTest() throws InterruptedException {
         final AtomicBoolean done = new AtomicBoolean(false); // Done flag for thread shutdown
         final AtomicInteger size = new AtomicInteger(); // Queue size
         final AtomicLong progress = new AtomicLong(); // Processed iterations count
-        final SingleConsumerLinkedArrayObjectQueue<Object> queue = new SingleConsumerLinkedArrayObjectQueue<>(); // Tested queue
+        final SingleConsumerQueue<Object> queue = new SingleConsumerLinkedObjectQueue<>(); // Tested queue
         final Thread consumer = new Thread(new Runnable() {
             @Override
             public void run() {
                 while (!done.get()) {
+                    QueueIterator<Object> it = queue.iterator();
+                    while (it.hasNext()) {
+                        it.next();
+                    }
                     if (queue.poll() != null) {
                         size.decrementAndGet();
                     }
@@ -33,9 +37,11 @@ public class SingleConsumerLinkedArrayObjectQueueTest {
             @Override
             public void run() {
                 while (!done.get()) {
-                    if (size.get() < 1) {
+                    if (size.get() < 5) {
                         queue.add(new Object());
                         size.incrementAndGet();
+                    } else {
+                        Thread.yield();
                     }
                 }
             }


### PR DESCRIPTION
I have a problem: some times server hangs up in method SingleConsumerLinkedArrayQueue.prePeek() with infinity loop on line:
```
                if (tail == n)
                    return false;

                while (n.next == null); // wait for next <== HERE
                Node next = n.next; // can't be null because we're called by the consumer
                clearNext(n);
                clearPrev(next);
```

I try to localize this problem and have a following way to reproduce it:

 * Open project in Idea;
 * Add breakpoint on SingleConsumerLinkedArrayQueue.java:70
```
                if (v == 0) {
                    // PUT BREAKPOINT HERE
                    v = 1;
                }
```
 * Run from Idea gradle task: quasar:quasar-core [jdk8Test] (it's run only SingleConsumerLinkedArrayObjectQueueTest.uglyTest())
 * On breakpoint simply press Resume (F9) to program continue.

After that "consumer" thread hangs in infinity loop on SingleConsumerLinkedArrayQueue.java:76

I tried to get rid of breakpoints in this test, but could not :(

I also do not understand how this queue works.

I tested this problem on Oracle JDK 1.8.0_45, Oracle JDK 1.8.0_60 and OpenJDK 1.8.0_45