### PR TITLE
Fix proposal for #168

### DIFF
--- a/quasar-core/src/jdk8test/java/co/paralleluniverse/fibers/lambdas/LambdaTest.java
+++ b/quasar-core/src/jdk8test/java/co/paralleluniverse/fibers/lambdas/LambdaTest.java
@@ -1,0 +1,57 @@
+/*
+ * Quasar: lightweight threads and actors for the JVM.
+ * Copyright (c) 2013-2014, Parallel Universe Software Co. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 3.0
+ * as published by the Free Software Foundation.
+ */
+package co.paralleluniverse.fibers.lambdas;
+
+import co.paralleluniverse.fibers.Fiber;
+import co.paralleluniverse.fibers.SuspendExecution;
+import co.paralleluniverse.fibers.Suspendable;
+import co.paralleluniverse.strands.Strand;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * @author circlespainter
+ */
+public class LambdaTest {
+    @Suspendable
+    @FunctionalInterface
+    private interface I {
+        @Suspendable
+        void doIt();
+    }
+
+    private void run(I i) throws ExecutionException, InterruptedException {
+        new Fiber() {
+            @Override
+            protected Object run() throws SuspendExecution, InterruptedException {
+                i.doIt();
+                return null;
+            }
+        }.start().join();
+    }
+
+    @Test
+    public void suspLambda() throws Exception {
+        run(() -> {
+            try {
+                Strand.sleep(10);
+            } catch (final SuspendExecution e) {
+                throw new AssertionError(e);
+            } catch (final InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
@@ -39,10 +39,12 @@ final class Classes {
     static final String ANNOTATION_DESC = "L" + ANNOTATION_NAME + ";";
     static final String DONT_INSTRUMENT_ANNOTATION_DESC = "L" + DONT_INSTRUMENT_ANNOTATION_NAME + ";";
     static final String ALREADY_INSTRUMENTED_DESC = Type.getDescriptor(Instrumented.class);
+    static final String LAMBDA_METHOD_PREFIX = "lambda$";
 
     private static final Set<String> yieldMethods = new HashSet<>(Arrays.asList(new String[] {
         "park", "yield", "parkAndUnpark", "yieldAndUnpark", "parkAndSerialize"
     }));
+
     static boolean isYieldMethod(String className, String methodName) {
         return FIBER_CLASS_NAME.equals(className) && yieldMethods.contains(methodName);
     }

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DefaultSuspendableClassifier.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/DefaultSuspendableClassifier.java
@@ -51,6 +51,10 @@ public class DefaultSuspendableClassifier implements SuspendableClassifier {
             // throws SuspendExecution
             if (checkExceptions(methodExceptions))
                 return SuspendableType.SUSPENDABLE;
+
+            // lambda$
+            if (methodName.startsWith(Classes.LAMBDA_METHOD_PREFIX))
+                return SuspendableType.SUSPENDABLE;
         } catch (Exception e) {
             e.printStackTrace();
             throw e;

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentMethod.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentMethod.java
@@ -355,7 +355,7 @@ class InstrumentMethod {
         for (Object o : mn.tryCatchBlocks) {
             final TryCatchBlockNode tcb = (TryCatchBlockNode) o;
 
-            if (SUSPEND_EXECUTION_NAME.equals(tcb.type) && !hasAnnotation) // we allow catch of SuspendExecution in method annotated with @Suspendable.
+            if (SUSPEND_EXECUTION_NAME.equals(tcb.type) && !hasAnnotation && !mn.name.startsWith(Classes.LAMBDA_METHOD_PREFIX)) // we allow catch of SuspendExecution only in methods annotated with @Suspendable and in lambda-generated ones.
                 throw new UnableToInstrumentException("catch for SuspendExecution", className, mn.name, mn.desc);
             if (handleProxyInvocations && UNDECLARED_THROWABLE_NAME.equals(tcb.type)) // we allow catch of SuspendExecution in method annotated with @Suspendable.
                 throw new UnableToInstrumentException("catch for UndeclaredThrowableException", className, mn.name, mn.desc);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspendableHelper.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspendableHelper.java
@@ -91,9 +91,9 @@ public final class SuspendableHelper {
     }
     
     public static boolean isSyntheticAndNotLambda(Member m) {
-        return m.isSynthetic() && !m.getName().startsWith("lambda$");
+        return m.isSynthetic() && !m.getName().startsWith(Classes.LAMBDA_METHOD_PREFIX);
     }
-    
+
     public static boolean isOptimized(Member m) {
         if (m == null)
             return false;


### PR DESCRIPTION
In this case a suspendable lambda is not used directly in a suspendable method nor passed directly as the fiber's target but rather invoked during a fiber's execution as a suspendable interface.

Since [there seems to be no way to annotate lambda literals as `@Suspendable`](http://stackoverflow.com/questions/22375891/annotating-the-functional-interface-of-a-lambda-expression) (apart from the uncomfortable `META-INF` files) the fix changes `DefaultSuspendableClassifier` to always consider `SUSPENDABLE` the methods prefixed by `lambda$`; it also allows them to catch `SuspendExecution` (in `InstrumentMethod`; this is needed because [it looks like no checked exceptions can exit lambdas](http://stackoverflow.com/questions/27644361/how-can-i-throw-checked-exceptions-from-inside-java-8-streams)). A test case is included.

Asking for review in case I'm missing something and because it is a change that can affect instrumentation performance (especially considering that lambdas will be used more and more). I don't think there will be any runtime performance impacts because we're just going to inspect a special class of (potentially suspendable) concrete methods always rather than only when annotated.