### PR TITLE
Exclude shaded variant of Kotlin's ModuleDescriptorImpl

### DIFF
--- a/quasar-kotlin/src/main/java/co/paralleluniverse/kotlin/KotlinClassifier.java
+++ b/quasar-kotlin/src/main/java/co/paralleluniverse/kotlin/KotlinClassifier.java
@@ -59,7 +59,9 @@ public class KotlinClassifier implements SuspendableClassifier {
 		// Class prefixes that are known not to suspend
 		excludePrefixes = new String[] {
 			// TODO: this specifically is also known to cause a `VerifyError` when instrumented, see #146
-			"kotlin/reflect/jvm/internal/impl/descriptors/impl/ModuleDescriptorImpl"
+			"kotlin/reflect/jvm/internal/impl/descriptors/impl/ModuleDescriptorImpl",
+			// Handle the same class, when shaded within kotlin-compiler[-embeddable]
+			"org/jetbrains/kotlin/descriptors/impl/ModuleDescriptorImpl"
 		};
 	}
 


### PR DESCRIPTION
#146 identified a quasar instrumentation problem that causes a `VerifyError` in Kotlin's `ModuleDescriptorImpl`. The fix for #146 explicitly excludes this class by its fully qualified name `kotlin.reflect.jvm.internal.impl.descriptors.impl.ModuleDescriptorImpl`, and this works, but this same class is shaded/repackaged as `org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl` within the kotlin-compiler[-embeddable] jars.

This fix adds the latter to the set of exclusions so the workaround applies to both cases.