### PR TITLE
Fixed typo in StrandFactory javadoc

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/strands/StrandFactory.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/StrandFactory.java
@@ -15,7 +15,7 @@
 package co.paralleluniverse.strands;
 
 /**
- * Creates new {@link Strand strnads} on demand.
+ * Creates new {@link Strand strands} on demand.
  */
 public interface StrandFactory {
     Strand newStrand(SuspendableCallable<?> target);


### PR DESCRIPTION
Fixed "strnads" to "strands"