### PR TITLE
Allow fibers to have a wider range of priorities

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -140,7 +140,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
     // private int preemptionCredits;
     private transient Thread runningThread;
     private final SuspendableCallable<V> target;
-    private byte priority;
+    private int priority;
     private transient ClassLoader contextClassLoader;
     private transient AccessControlContext inheritedAccessControlContext;
     // These are typed as Object because they store JRE-internal ThreadLocalMap objects, which is a package private
@@ -230,6 +230,21 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
         this(name, defaultScheduler(), stackSize, target);
     }
 
+    /**
+     * The minimum priority that a fiber can have.
+     */
+    public final static int MIN_PRIORITY = Integer.MIN_VALUE;
+
+    /**
+     * The default priority that is assigned to a fiber.
+     */
+    public final static int NORM_PRIORITY = 0;
+
+    /**
+     * The maximum priority that a fiber can have.
+     */
+    public final static int MAX_PRIORITY = Integer.MAX_VALUE;
+
     private static FiberScheduler defaultScheduler() {
         final Fiber parent = currentFiber();
         if (parent == null)
@@ -310,7 +325,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
     public Fiber setPriority(int newPriority) {
         if (newPriority > MAX_PRIORITY || newPriority < MIN_PRIORITY)
             throw new IllegalArgumentException();
-        this.priority = (byte) newPriority;
+        this.priority = newPriority;
         return this;
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/strands/Strand.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/strands/Strand.java
@@ -56,21 +56,6 @@ public abstract class Strand {
     }
 
     /**
-     * The minimum priority that a strand can have.
-     */
-    public final static int MIN_PRIORITY = 1;
-
-    /**
-     * The default priority that is assigned to a strand.
-     */
-    public final static int NORM_PRIORITY = 5;
-
-    /**
-     * The maximum priority that a strand can have.
-     */
-    public final static int MAX_PRIORITY = 10;
-
-    /**
      * A strand's running state
      */
     public static enum State {
@@ -349,6 +334,36 @@ public abstract class Strand {
             return Fiber.interrupted();
         else
             return Thread.interrupted();
+    }
+
+    /**
+     * The minimum priority that the current strand can have.
+     */
+    public static int MIN_PRIORITY() {
+        if (isCurrentFiber())
+            return Fiber.MIN_PRIORITY;
+        else
+            return Thread.MIN_PRIORITY;
+    }
+
+    /**
+     * The default priority that is assigned to the current strand.
+     */
+    public static int NORM_PRIORITY() {
+        if (isCurrentFiber())
+            return Fiber.NORM_PRIORITY;
+        else
+            return Thread.NORM_PRIORITY;
+    }
+
+    /**
+     * The maximum priority that the current strand can have.
+     */
+    public static int MAX_PRIORITY() {
+        if (isCurrentFiber())
+            return Fiber.MAX_PRIORITY;
+        else
+            return Thread.MAX_PRIORITY;
     }
 
     /**

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberTest.java
@@ -114,19 +114,19 @@ public class FiberTest implements Serializable {
             }
         });
 
-        assertThat(fiber.getPriority(), is(Strand.NORM_PRIORITY));
+        assertThat(fiber.getPriority(), is(Fiber.NORM_PRIORITY));
         
         fiber.setPriority(3);
         assertThat(fiber.getPriority(), is(3));
         
         try {
-            fiber.setPriority(Strand.MAX_PRIORITY + 1);
+            fiber.setPriority(Fiber.MAX_PRIORITY + 1);
             fail();
         } catch (IllegalArgumentException e) {
         }
 
         try {
-            fiber.setPriority(Strand.MIN_PRIORITY - 1);
+            fiber.setPriority(Fiber.MIN_PRIORITY - 1);
             fail();
         } catch (IllegalArgumentException e) {
         }


### PR DESCRIPTION
As discussed in #195.

This PR can be used if having a wider range of priorities turns out to be useful.  Fibers are no longer restricted to the same priority range as a Thread.  Hopefully this does not complicate the code too much.

I'm not sure if this follows correct code conventions consistent with the rest of the project, so please let me know if there are any minor things that I should fix.

@pron I realize that you already stated that you are reluctant to make this change unless there is a compelling reason, so please treat this PR as merely a suggestion in the event that a compelling reason arises.  If there is not a good reason to make the change, then feel free to reject the PR.  I just wanted to post this in case it is useful to anyone or saves you some time. :smile: 