### PR TITLE
Skip getClassContext() that don't match stack frame class names

### DIFF
--- a/quasar-core/src/jdk8test/java/co/paralleluniverse/common/util/ExtendedStackTraceClassContextTest.java
+++ b/quasar-core/src/jdk8test/java/co/paralleluniverse/common/util/ExtendedStackTraceClassContextTest.java
@@ -1,0 +1,34 @@
+/*
+ * Quasar: lightweight threads and actors for the JVM.
+ * Copyright (c) 2013-2014, Parallel Universe Software Co. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 3.0
+ * as published by the Free Software Foundation.
+ */
+package co.paralleluniverse.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author candrews
+ */
+public class ExtendedStackTraceClassContextTest {
+    @Test
+    public void lambdaInCallStackTest() throws Exception {
+        ((Runnable) (() -> {
+            new ExtendedStackTraceClassContext().get();
+        })).run();
+    }
+    @Test
+    public void NoLambdaInCallStackTest() throws Exception {
+        new ExtendedStackTraceClassContext().get();
+    }
+}
+

--- a/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTraceClassContext.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/util/ExtendedStackTraceClassContext.java
@@ -51,8 +51,12 @@ class ExtendedStackTraceClassContext extends ExtendedStackTrace {
                                 clazz = null;
                             } else
                                 clazz = classContext[k];
-                            est[i - 1] = new BasicExtendedStackTraceElement(ste, clazz);
-                            // System.out.println(">>>> " + k + ": " + (clazz != null ? clazz.getName() : null) + " :: " + i + ": " + ste);
+                            if(clazz != null && !ste.getClassName().equals(clazz.getName())) {
+                                i--;
+                            } else {
+                                est[i - 1] = new BasicExtendedStackTraceElement(ste, clazz);
+                                // System.out.println(">>>> " + k + ": " + (clazz != null ? clazz.getName() : null) + " :: " + i + ": " + ste);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
java.lang.SecurityManager.getClassContext() includes lambda generated classes but, after 8u60, java.lang.Throwable.getStackTrace() does not. This problem manifest as an IllegalArgumentException in co.paralleluniverse.common.util.ExtendedStackTraceElement.ExtendedStackTraceElement when the call stack contains one or more lambda.

See http://bugs.java.com/view_bug.do?bug_id=8025636