### PR TITLE
Allow Quasar to work with multiple classloaders.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -424,6 +424,15 @@ project (':quasar-core') {
             compileClasspath += jdk8.output + jdk8test.compileClasspath + jdk8test.output
             runtimeClasspath += compileClasspath + jdk8test.runtimeClasspath
         }
+
+        classloadertest {
+            java {
+                srcDir 'src/classloadertest/java'
+            }
+
+            compileClasspath += jdk7.output + test.compileClasspath
+            runtimeClasspath += compileClasspath + test.runtimeClasspath
+        }
     }
 
     configurations {
@@ -496,7 +505,7 @@ project (':quasar-core') {
             }
         }
 
-        def testTask = task("${set.name}Test", type: Test, dependsOn: shadowJarTask) {
+        def testTask = task("${set.name}Test", type: Test, dependsOn: [shadowJarTask, compileClassloadertestJava]) {
             testClassesDir = project.sourceSets["${set.name}test"].output.classesDir
             classpath = project.sourceSets["${set.name}test"].runtimeClasspath
 

--- a/quasar-core/src/classloadertest/java/co.paralleluniverse.fibers.dynamic/DynamicallyLoadedFiber.java
+++ b/quasar-core/src/classloadertest/java/co.paralleluniverse.fibers.dynamic/DynamicallyLoadedFiber.java
@@ -1,0 +1,38 @@
+package co.paralleluniverse.fibers.dynamic;
+
+import co.paralleluniverse.fibers.Fiber;
+import co.paralleluniverse.fibers.SuspendExecution;
+
+import java.util.ArrayList;
+
+public class DynamicallyLoadedFiber extends Fiber<ArrayList<String>> {
+    @Override
+    protected ArrayList<String> run() throws SuspendExecution, InterruptedException {
+        ArrayList<String> results = new ArrayList<>();
+        Test testClass = new Test();
+        results.add("a");
+        Fiber.park();
+        results.add("b");
+        testClass.test(results);
+        results.add("c");
+        return results;
+    }
+
+    private static class Base {
+        public void baseTest(ArrayList<String> results) throws SuspendExecution {
+            results.add("base1");
+            Fiber.park();
+            results.add("base2");
+        }
+    }
+
+    private static class Test extends Base {
+        public void test(ArrayList<String> results) throws SuspendExecution {
+            results.add("o1");
+            Fiber.park();
+            results.add("o2");
+            baseTest(results);
+            results.add("o3");
+        }
+    }
+}

--- a/quasar-core/src/classloadertest/java/co.paralleluniverse.fibers.dynamic/DynamicallyLoadedSuspendable.java
+++ b/quasar-core/src/classloadertest/java/co.paralleluniverse.fibers.dynamic/DynamicallyLoadedSuspendable.java
@@ -1,0 +1,75 @@
+package co.paralleluniverse.fibers.dynamic;
+
+import co.paralleluniverse.common.test.TestInterface;
+import co.paralleluniverse.common.test.TestInterface2;
+import co.paralleluniverse.fibers.Fiber;
+import co.paralleluniverse.fibers.SuspendExecution;
+import co.paralleluniverse.fibers.Suspendable;
+
+import java.util.ArrayList;
+
+public class DynamicallyLoadedSuspendable implements TestInterface {
+    @Suspendable
+    public void test(ArrayList<String> results) {
+        results.add("a");
+        TestInterface referencedSuspend = new ReferencedSuspendable();
+        TestInterface2 indirectSuspend = new IndirectSuspendable();
+        results.add("b");
+        try {
+            results.add("c");
+            Fiber.park();
+            results.add("d");
+        } catch (SuspendExecution ex) {
+
+        }
+        results.add("e");
+        referencedSuspend.test(results);
+        results.add("f");
+        indirectSuspend.test(results, referencedSuspend);
+        results.add("g");
+        while (true) {
+            results.add("h");
+            indirectSuspend.test(results, referencedSuspend);
+            results.add("i");
+        }
+    }
+
+    private static class BaseSuspendable {
+        @Suspendable
+        public void baseTest(ArrayList<String> results) {
+            try {
+                results.add("b1");
+                Fiber.park();
+                results.add("b2");
+            } catch (SuspendExecution ex) {
+
+            }
+        }
+    }
+
+    private static class ReferencedSuspendable extends BaseSuspendable implements TestInterface {
+        @Override
+        @Suspendable
+        public void test(ArrayList<String> results) {
+            try {
+                results.add("d1");
+                Fiber.park();
+                results.add("d2");
+            } catch (SuspendExecution ex) {
+
+            }
+            baseTest(results);
+        }
+    }
+
+    private static class IndirectSuspendable extends BaseSuspendable implements TestInterface2 {
+        @Override
+        @Suspendable
+        public void test(ArrayList<String> results, TestInterface target) {
+            results.add("o1");
+            target.test(results);
+            results.add("o2");
+            baseTest(results);
+        }
+    }
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/common/test/TestInterface.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/test/TestInterface.java
@@ -1,0 +1,10 @@
+package co.paralleluniverse.common.test;
+
+import co.paralleluniverse.fibers.Suspendable;
+
+import java.util.ArrayList;
+
+public interface TestInterface {
+    @Suspendable
+    void test(ArrayList<String> results);
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/common/test/TestInterface2.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/common/test/TestInterface2.java
@@ -1,0 +1,10 @@
+package co.paralleluniverse.common.test;
+
+import co.paralleluniverse.fibers.Suspendable;
+
+import java.util.ArrayList;
+
+public interface TestInterface2 {
+    @Suspendable
+    void test(ArrayList<String> results, TestInterface target);
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentationTask.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentationTask.java
@@ -41,19 +41,12 @@
  */
 package co.paralleluniverse.fibers.instrument;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.List;
-import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.DirectoryScanner;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.Task;
-import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.*;
+import org.apache.tools.ant.types.*;
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
 
 /**
  * <p>
@@ -174,7 +167,7 @@ public class InstrumentationTask extends Task {
             instrumentor.log(LogLevel.INFO, "Instrumenting " + instrumentor.getWorkList().size() + " classes");
 
             for (MethodDatabase.WorkListEntry f : instrumentor.getWorkList())
-                instrumentClass(instrumentor, f);
+                instrumentClass(cl, instrumentor, f);
 
         } catch (Exception ex) {
             log(ex.getMessage());
@@ -182,12 +175,12 @@ public class InstrumentationTask extends Task {
         }
     }
 
-    private void instrumentClass(QuasarInstrumentor instrumentor, MethodDatabase.WorkListEntry entry) {
+    private void instrumentClass(ClassLoader cl, QuasarInstrumentor instrumentor, MethodDatabase.WorkListEntry entry) {
         if (!instrumentor.shouldInstrument(entry.name))
             return;
         try {
             try (FileInputStream fis = new FileInputStream(entry.file)) {
-                final byte[] newClass = instrumentor.instrumentClass(entry.name, fis);
+                final byte[] newClass = instrumentor.instrumentClass(cl, entry.name, fis);
 
                 if (writeClasses) {
                     try (FileOutputStream fos = new FileOutputStream(entry.file)) {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/JavaAgent.java
@@ -150,7 +150,7 @@ public class JavaAgent {
         });
 
         Retransform.instrumentation = instrumentation;
-        Retransform.db = instrumentor.getMethodDatabase();
+        Retransform.db = instrumentor.getMethodDatabase(cl);
         Retransform.classLoaders = classLoaders;
 
         instrumentation.addTransformer(new Transformer(instrumentor), true);
@@ -184,7 +184,10 @@ public class JavaAgent {
             classLoaders.add(new WeakReference<>(loader));
 
             try {
-                final byte[] transformed = instrumentor.instrumentClass(className, classfileBuffer);
+                if (loader == null) {
+                    loader = Thread.currentThread().getContextClassLoader();
+                }
+                final byte[] transformed = instrumentor.instrumentClass(loader, className, classfileBuffer);
 
                 if (transformed != null)
                     Retransform.afterTransform(className, classBeingRedefined, transformed);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarURLClassLoaderHelper.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/QuasarURLClassLoaderHelper.java
@@ -13,25 +13,17 @@
  */
 package co.paralleluniverse.fibers.instrument;
 
-import com.google.common.io.ByteStreams;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.nio.ByteBuffer;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.CodeSigner;
-import java.security.PrivilegedExceptionAction;
+import com.google.common.io.*;
+import sun.misc.*;
+
+import java.io.*;
+import java.lang.reflect.*;
+import java.net.*;
+import java.nio.*;
+import java.security.*;
 import java.security.cert.Certificate;
-import java.util.Arrays;
-import java.util.jar.Manifest;
-import sun.misc.Resource;
-import sun.misc.URLClassPath;
+import java.util.*;
+import java.util.jar.*;
 
 /**
  *
@@ -97,7 +89,7 @@ public final class QuasarURLClassLoaderHelper {
         if (is != null && resourceName.endsWith(".class")) {
             try {
                 byte[] bytes = ByteStreams.toByteArray(is);
-                byte[] instrumented = instrumentor.instrumentClass(resourceName.substring(0, resourceName.length() - ".class".length()), bytes);
+                byte[] instrumented = instrumentor.instrumentClass(cl, resourceName.substring(0, resourceName.length() - ".class".length()), bytes);
                 return new ByteArrayInputStream(instrumented);
             } catch (final IOException e) {
                 return new InputStream() {
@@ -127,7 +119,7 @@ public final class QuasarURLClassLoaderHelper {
                     } else
                         bytes = res.getBytes();
                     try {
-                        this.instrumented = instrumentor.instrumentClass(className, bytes);
+                        this.instrumented = instrumentor.instrumentClass(cl, className, bytes);
                     } catch (Exception ex) {
                         if (MethodDatabase.isProblematicClass(className))
                             instrumentor.log(LogLevel.INFO, "Skipping problematic class instrumentation %s - %s %s", className, ex, Arrays.toString(ex.getStackTrace()));

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/BlockingTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/BlockingTest.java
@@ -28,14 +28,13 @@
  */
 package co.paralleluniverse.fibers.instrument;
 
-import co.paralleluniverse.fibers.Instrumented;
-import co.paralleluniverse.fibers.SuspendExecution;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashSet;
-import java.util.Locale;
+import co.paralleluniverse.fibers.*;
+import org.junit.*;
+
+import java.io.*;
+import java.util.*;
+
 import static org.junit.Assert.*;
-import org.junit.Test;
 
 /**
  * Test to check blocking call detection
@@ -57,7 +56,7 @@ public class BlockingTest {
         msgs.add("Method " + className + "#t_join3(Ljava/lang/Thread;)V contains potentially blocking call to java/lang/Thread#join(JI)V");
 
         final QuasarInstrumentor instrumentor = new QuasarInstrumentor(BlockingTest.class.getClassLoader());
-        final MethodDatabase db = instrumentor.getMethodDatabase();
+        final MethodDatabase db = instrumentor.getMethodDatabase(BlockingTest.class.getClassLoader());
         db.setAllowBlocking(true);
         db.setLog(new Log() {
             @Override
@@ -75,7 +74,7 @@ public class BlockingTest {
         });
 
         try (InputStream in = BlockingTest.class.getResourceAsStream("BlockingTest.class")) {
-            instrumentor.instrumentClass(BlockingTest.class.getName(), in, true);
+            instrumentor.instrumentClass(BlockingTest.class.getClassLoader(), BlockingTest.class.getName(), in, true);
         }
 
         assertTrue("Expected messages not generated: " + msgs.toString(), msgs.isEmpty());

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ClassLoaderTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/instrument/ClassLoaderTest.java
@@ -1,0 +1,156 @@
+package co.paralleluniverse.fibers.instrument;
+
+import co.paralleluniverse.common.test.*;
+import co.paralleluniverse.fibers.*;
+import co.paralleluniverse.strands.*;
+import org.junit.*;
+
+import java.lang.reflect.*;
+import java.net.*;
+import java.util.*;
+
+import static co.paralleluniverse.fibers.TestsHelper.*;
+import static org.junit.Assert.*;
+
+public class ClassLoaderTest {
+    /**
+     * Test instrumentation of @Suspendable classes loaded dynamically in a custom classloader
+     */
+    @Test
+    public void testSuspendableMethodsLoadedDynamically() {
+        final ArrayList<String> results = new ArrayList<>();
+        try {
+            try {
+                URI currentURL = this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI();
+                System.out.println(currentURL.toString());
+                URL testClassesURL = currentURL.resolve("../classloadertest/").toURL();
+                System.out.println(testClassesURL.toString());
+                ClassLoader cl = new URLClassLoader(new URL[]{testClassesURL});
+                Class<?> testClass = cl.loadClass("co.paralleluniverse.fibers.dynamic.DynamicallyLoadedSuspendable");
+                Constructor<?> constructor = testClass.getConstructor();
+                final TestInterface testInstance = (TestInterface) constructor.newInstance();
+
+                assertEquals(cl, testInstance.getClass().getClassLoader());
+                assertEquals(ClassLoader.getSystemClassLoader(), TestInterface.class.getClassLoader());
+
+                Fiber co = new Fiber((String) null, null, (SuspendableCallable) null) {
+                    @Override
+                    protected Object run() throws SuspendExecution, InterruptedException {
+                        testInstance.test(results);
+                        return null;
+                    }
+                };
+                for (int i = 0; i < 6; i++) {
+                    exec(co);
+                }
+            } catch (Exception ex) {
+                throw new AssertionError(ex);
+            }
+        } finally {
+            System.out.println(results);
+        }
+
+        assertEquals(17, results.size());
+        assertEquals(Arrays.asList("a", "b", "c", "d", "e", "d1", "d2", "b1", "b2", "f", "o1", "d1", "d2", "b1", "b2", "o2", "b1"), results);
+    }
+
+    /**
+     * Test instrumentation of @Suspendable class loaded twice in distinct classloaders to ensure it is instrumented properly each time
+     */
+    @Test
+    public void testSuspendableClassLoadedTwice() {
+        final ArrayList<String> results1 = new ArrayList<>();
+        final ArrayList<String> results2 = new ArrayList<>();
+        try {
+            try {
+                URI currentURL = this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI();
+                System.out.println(currentURL.toString());
+                URL testClassesURL = currentURL.resolve("../classloadertest/").toURL();
+                System.out.println(testClassesURL.toString());
+                ClassLoader cl1 = new URLClassLoader(new URL[]{testClassesURL});
+                ClassLoader cl2 = new URLClassLoader(new URL[]{testClassesURL});
+                Class<?> testClass1 = cl1.loadClass("co.paralleluniverse.fibers.dynamic.DynamicallyLoadedSuspendable");
+                Class<?> testClass2 = cl2.loadClass("co.paralleluniverse.fibers.dynamic.DynamicallyLoadedSuspendable");
+                Constructor<?> constructor1 = testClass1.getConstructor();
+                Constructor<?> constructor2 = testClass2.getConstructor();
+                final TestInterface testInstance1 = (TestInterface) constructor1.newInstance();
+                final TestInterface testInstance2 = (TestInterface) constructor2.newInstance();
+
+                assertEquals(cl1, testInstance1.getClass().getClassLoader());
+                assertEquals(cl2, testInstance2.getClass().getClassLoader());
+                assertEquals(ClassLoader.getSystemClassLoader(), TestInterface.class.getClassLoader());
+
+                Fiber co1 = new Fiber((String) null, null, (SuspendableCallable) null) {
+                    @Override
+                    protected Object run() throws SuspendExecution, InterruptedException {
+                        testInstance1.test(results1);
+                        return null;
+                    }
+                };
+
+                Fiber co2 = new Fiber((String) null, null, (SuspendableCallable) null) {
+                    @Override
+                    protected Object run() throws SuspendExecution, InterruptedException {
+                        testInstance2.test(results2);
+                        return null;
+                    }
+                };
+                exec(co2);
+                for (int i = 0; i < 6; i++) {
+                    exec(co1);
+                }
+                exec(co2);
+                exec(co2);
+                exec(co2);
+            } catch (Exception ex) {
+                throw new AssertionError(ex);
+            }
+        } finally {
+            System.out.println(results1);
+            System.out.println(results2);
+        }
+
+        assertEquals(17, results1.size());
+        assertEquals(Arrays.asList("a", "b", "c", "d", "e", "d1", "d2", "b1", "b2", "f", "o1", "d1", "d2", "b1", "b2", "o2", "b1"), results1);
+        assertEquals(12, results2.size());
+        assertEquals(Arrays.asList("a", "b", "c", "d", "e", "d1", "d2", "b1", "b2", "f", "o1", "d1"), results2);
+    }
+
+    /**
+     * Test instrumentation of a fiber implementation class that is loaded dynamically.
+     */
+    @Test
+    public void testDynamicallyLoadedFiber() {
+        ArrayList<String> results = null;
+        try {
+            try {
+                URI currentURL = this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI();
+                System.out.println(currentURL.toString());
+                URL testClassesURL = currentURL.resolve("../classloadertest/").toURL();
+                System.out.println(testClassesURL.toString());
+                ClassLoader cl = new URLClassLoader(new URL[]{testClassesURL});
+                Class<?> testClass = cl.loadClass("co.paralleluniverse.fibers.dynamic.DynamicallyLoadedFiber");
+                Constructor<?> constructor = testClass.getConstructor();
+                final Fiber<ArrayList<String>> testInstance = (Fiber<ArrayList<String>>) constructor.newInstance();
+
+                assertEquals(cl, testInstance.getClass().getClassLoader());
+                assertEquals(ClassLoader.getSystemClassLoader(), TestInterface.class.getClassLoader());
+
+                for (int i = 0; i < 4; i++) {
+                    assertFalse(testInstance.isDone());
+                    exec(testInstance);
+                }
+                assertTrue(testInstance.isDone());
+                results = testInstance.get();
+            } catch (Exception ex) {
+                throw new AssertionError(ex);
+            }
+        } finally {
+            System.out.println(results);
+        }
+
+        assertEquals(8, results.size());
+        assertEquals(Arrays.asList("a", "b", "o1", "o2", "base1", "base2", "o3", "c"), results);
+    }
+
+}


### PR DESCRIPTION
Hi Ron, Fabio,

This commit is the work of my colleague Matthew Nesbit. It upgrades Quasar so it can operate with multiple classloaders, which is useful if you wish to dynamically load fiber implementations from plugins, inside a sandbox etc. The unit tests all pass for me, and we have it working internally, but there may still be issues or a need to tweak things further.