### PR TITLE
Fix #211

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentMethod.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentMethod.java
@@ -489,6 +489,11 @@ class InstrumentMethod {
                 if (yieldReturnsValue)
                     mv.visitVarInsn(Opcodes.ILOAD, lvarResumed); // ... and replace the returned value with the value of resumed
 
+                // See #211: if Fiber.park() is the last call before catch, ASM generates
+                // empty handlers (start_pc = end_pc) that won't pass ASM's nor JVM's bytecode checker because of
+                // exception_table's spec here: https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.3
+                mv.visitInsn(Opcodes.NOP);
+
                 dumpCodeBlock(mv, i, 1 /* skip the call */);
             } else {
                 final Label lbl = new Label();

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentMethod.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/InstrumentMethod.java
@@ -787,6 +787,7 @@ class InstrumentMethod {
 
                 // need to split try/catch around the suspendable call
                 if (start == fi.endInstruction) {
+                    // Starts exactly at the suspendable call => just make it start after it
                     tcb.start = fi.createAfterLabel();
                 } else {
                     if (end > fi.endInstruction) {
@@ -796,6 +797,7 @@ class InstrumentMethod {
                         mn.tryCatchBlocks.add(i + 1, tcb2);
                     }
 
+                    // Make it end before the suspendable call
                     tcb.end = fi.createBeforeLabel();
                 }
             }


### PR DESCRIPTION
Hi @pron, the exception handlers generated by ASM when a yield call is placed just before a catch block include one with size 0 (`startpc` = `endpc` and the latter is exclusive, https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.3, so ASM's checker and JVM's verifier complain about it).

I think this is triggered by the `try`/`catch` splitting but I couldn't fix it there (I think it's not yet possible to check for empty `try`/`catch` blocks at that point as the code is not freezed) so I'm preventing it by adding a `NOP` after the yield call itself.

I don't think there'll be any performance impact but I'm not 100% sure as I don't know how JVMs treat `NOP`s; I guess they might choose to optimize them out or to translate them to actual CPU `NOP`s, perhaps depending on arch. and circumstances.

If you can figure out a way that doesn't need to add bytecode, f.e. somehow actually removing `try`/`catch` blocks that would result empty after instrumentation, it would probably be better.

Apart from the empty handler ASM generates, the handlers table looks strange in other ways (as well as the ASM-generated bytecode itself that contains several `NOP`s in this case) but I haven't further investigated; anyway I think It might be well worth to invest some more time and try to build a minimal case exhibiting this strange behavior and then submit it to the ASM guys.