### PR TITLE
Fix resource leaks in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,7 @@ subprojects {
             jvmArgs "-javaagent:${configurations.timewarp.singleFile}=3" // slow clock down x3
         }
 
-        jvmArgs "-Xmx2048m"
+        jvmArgs "-Xmx1024m"
         if (!project.ext.java8) {
             jvmArgs "-XX:MaxPermSize=512m" // Travis is having some trouble with PermGen
         }

--- a/quasar-actors/src/test/java/co/paralleluniverse/actors/ActorTest.java
+++ b/quasar-actors/src/test/java/co/paralleluniverse/actors/ActorTest.java
@@ -43,6 +43,7 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.After;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 
@@ -65,6 +66,11 @@ public class ActorTest {
 
     public ActorTest() {
         scheduler = new FiberForkJoinScheduler("test", 4, null, false);
+    }
+
+    @After
+    public void tearDown() {
+    	  scheduler.shutdown();
     }
 
     private <Message, V> Actor<Message, V> spawnActor(Actor<Message, V> actor) {

--- a/quasar-actors/src/test/java/co/paralleluniverse/actors/behaviors/ProxyServerTest.java
+++ b/quasar-actors/src/test/java/co/paralleluniverse/actors/behaviors/ProxyServerTest.java
@@ -53,6 +53,7 @@ public class ProxyServerTest {
     @After
     public void tearDown() {
         ActorRegistry.clear();
+        scheduler.shutdown();
     }
 
     static final MailboxConfig mailboxConfig = new MailboxConfig(10, Channels.OverflowPolicy.THROW);

--- a/quasar-actors/src/test/java/co/paralleluniverse/actors/behaviors/ServerTest.java
+++ b/quasar-actors/src/test/java/co/paralleluniverse/actors/behaviors/ServerTest.java
@@ -60,6 +60,7 @@ public class ServerTest {
     @After
     public void tearDown() {
         ActorRegistry.clear();
+        scheduler.shutdown();
     }
 
     static final MailboxConfig mailboxConfig = new MailboxConfig(10, Channels.OverflowPolicy.THROW);

--- a/quasar-actors/src/test/java/co/paralleluniverse/actors/behaviors/SupervisorTest.java
+++ b/quasar-actors/src/test/java/co/paralleluniverse/actors/behaviors/SupervisorTest.java
@@ -60,6 +60,7 @@ public class SupervisorTest {
     @After
     public void tearDown() {
         ActorRegistry.clear();
+        scheduler.shutdown();
     }
     
     private static final Logger LOG = LoggerFactory.getLogger(SupervisorActor.class);

--- a/quasar-core/src/jdk7/java/co/paralleluniverse/fibers/FiberForkJoinScheduler.java
+++ b/quasar-core/src/jdk7/java/co/paralleluniverse/fibers/FiberForkJoinScheduler.java
@@ -93,6 +93,11 @@ public class FiberForkJoinScheduler extends FiberScheduler {
 
         this.timer = timeService != null ? timeService : createTimer(fjPool, getMonitor());
     }
+    
+    public void shutdown() {
+        this.timer.shutdown();
+        super.shutdown();
+    }
 
     private ForkJoinPool createForkJoinPool(String name, int parallelism, UncaughtExceptionHandler exceptionHandler, MonitorType monitorType) {
         final MonitoredForkJoinPool pool = new MonitoredForkJoinPool(name, parallelism, new ExtendedForkJoinWorkerFactory(name) {

--- a/quasar-core/src/jdk8/java/co/paralleluniverse/fibers/FiberForkJoinScheduler.java
+++ b/quasar-core/src/jdk8/java/co/paralleluniverse/fibers/FiberForkJoinScheduler.java
@@ -94,6 +94,11 @@ public class FiberForkJoinScheduler extends FiberScheduler {
         this.timer = timeService != null ? timeService : createTimer(fjPool, getMonitor());
     }
 
+    public void shutdown() {
+        this.timer.shutdown();
+        super.shutdown();
+    }
+
     private ForkJoinPool createForkJoinPool(String name, int parallelism, UncaughtExceptionHandler exceptionHandler, MonitorType monitorType) {
         final MonitoredForkJoinPool pool = new MonitoredForkJoinPool(name, parallelism, new ExtendedForkJoinWorkerFactory(name) {
             @Override

--- a/quasar-core/src/jdk8test/java/co/paralleluniverse/fibers/futures/AsyncCompletionStageTest.java
+++ b/quasar-core/src/jdk8test/java/co/paralleluniverse/fibers/futures/AsyncCompletionStageTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutionException;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
+import org.junit.After;
 
 /**
  *
@@ -32,6 +33,11 @@ public class AsyncCompletionStageTest {
 
     public AsyncCompletionStageTest() {
         scheduler = new FiberForkJoinScheduler("test", 4, null, false);
+    }
+
+    @After
+    public void tearDown() {
+        scheduler.shutdown();
     }
 
     @Test

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberExecutorScheduler.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberExecutorScheduler.java
@@ -62,6 +62,11 @@ public class FiberExecutorScheduler extends FiberScheduler implements Executor {
         this(name, executor, null, false);
     }
 
+    public void shutdown() {
+        this.timer.shutdown();
+        super.shutdown();
+    }
+
     @Override
     protected boolean isCurrentThreadInScheduler() {
         return false;

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberScheduler.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberScheduler.java
@@ -54,6 +54,9 @@ public abstract class FiberScheduler implements FiberFactory, StrandFactory {
                 throw new RuntimeException("Unsupported monitor type: " + monitorType);
         }
     }
+    
+    public void shutdown() {
+    }
 
     public String getName() {
         return name;

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberTimedScheduler.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberTimedScheduler.java
@@ -346,7 +346,7 @@ public class FiberTimedScheduler {
      * be cancelled.
      */
     public void shutdown() {
-        assert false;
+//      assert false;
         mainLock.lock();
         try {
             if (state < SHUTDOWN)

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberTimedScheduler.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/FiberTimedScheduler.java
@@ -355,6 +355,11 @@ public class FiberTimedScheduler {
             mainLock.unlock();
         }
     }
+    
+    public void finalize() throws Throwable {
+        shutdown();
+        super.finalize();
+    }
 
     /**
      * Attempts to stop all actively executing tasks, halts the

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberAsyncTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberAsyncTest.java
@@ -51,6 +51,11 @@ public class FiberAsyncTest {
         scheduler = new FiberForkJoinScheduler("test", 4, null, false);
     }
 
+    @After
+    public void tearDown() {
+        scheduler.shutdown();
+    }
+
     interface MyCallback {
         void call(String str);
 

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/FiberTest.java
@@ -43,6 +43,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.hamcrest.CoreMatchers.*;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.rules.TestName;
@@ -70,6 +71,12 @@ public class FiberTest implements Serializable {
 //    }
     public FiberTest(FiberScheduler scheduler) {
         this.scheduler = scheduler;
+    }
+
+    @After
+    public void tearDown() {
+        // Cannot shutdown FiberScheduler, as it is reused over multiple tests. So these FiberSchedulers and their associated threads will be kept over the whole test run.
+//      scheduler.shutdown();
     }
 
     @Parameterized.Parameters

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/futures/AsyncListenableFutureTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/futures/AsyncListenableFutureTest.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import java.util.concurrent.ExecutionException;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -45,6 +46,11 @@ public class AsyncListenableFutureTest {
 
     public AsyncListenableFutureTest() {
         scheduler = new FiberForkJoinScheduler("test", 4, null, false);
+    }
+
+    @After
+    public void tearDown() {
+        scheduler.shutdown();
     }
 
     @Test

--- a/quasar-core/src/test/java/co/paralleluniverse/fibers/io/FiberAsyncIOTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/fibers/io/FiberAsyncIOTest.java
@@ -65,6 +65,7 @@ public class FiberAsyncIOTest {
 
     @After
     public void tearDown() {
+        scheduler.shutdown();
     }
 
     @Test

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/ChannelTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/ChannelTest.java
@@ -102,6 +102,7 @@ public class ChannelTest {
 
     @After
     public void tearDown() {
+        scheduler.shutdown();
     }
 
     @Test

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/GeneralSelectorTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/GeneralSelectorTest.java
@@ -82,6 +82,11 @@ public class GeneralSelectorTest {
         fiber = true;
     }
 
+    @After
+    public void tearDown() {
+        scheduler.shutdown();
+    }
+
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TickerChannelTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TickerChannelTest.java
@@ -50,6 +50,11 @@ public class TickerChannelTest {
         scheduler = new FiberForkJoinScheduler("test", 4, null, false);
     }
 
+    @After
+    public void tearDown() {
+        scheduler.shutdown();
+    }
+
     @Test
     public void testMultipleConsumersAlwaysAscending() throws Exception {
         final Channel<Integer> sch = Channels.newChannel(bufferSize, Channels.OverflowPolicy.DISPLACE);

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TransferSelectorTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TransferSelectorTest.java
@@ -79,6 +79,7 @@ public class TransferSelectorTest {
 
     @After
     public void tearDown() {
+        scheduler.shutdown();
     }
 
     @Test

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TransformingChannelTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/TransformingChannelTest.java
@@ -105,6 +105,7 @@ public class TransformingChannelTest {
 
     @After
     public void tearDown() {
+        scheduler.shutdown();
     }
 
     @Test

--- a/quasar-core/src/test/java/co/paralleluniverse/strands/channels/transfer/PipelineTest.java
+++ b/quasar-core/src/test/java/co/paralleluniverse/strands/channels/transfer/PipelineTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.After;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
@@ -66,6 +67,11 @@ public class PipelineTest {
         this.singleConsumer = singleConsumer;
         this.singleProducer = singleProducer;
         this.parallelism = parallelism;
+    }
+
+    @After
+    public void tearDown() {
+        scheduler.shutdown();
     }
 
     @Parameterized.Parameters


### PR DESCRIPTION
Many tests create their own FiberScheduler. These objects do not seem to get reclaimed automatically (at least under OpenJDK 1.8.0), and each FiberScheduler entails at least one Thread. Hence, when testing everything at once, the number of Threads overwhelm the system and more Threads cannot be created, leading to OutOfMemoryErrors and thus test failures. However, the tests themselves would complete without failure if they were executed in isolation.

This fixes this issue by making the tests clean up after themselves.