### PR TITLE
:bug: Fix #163

### DIFF
--- a/quasar-actors/src/main/java/co/paralleluniverse/actors/behaviors/RequestMessage.java
+++ b/quasar-actors/src/main/java/co/paralleluniverse/actors/behaviors/RequestMessage.java
@@ -26,6 +26,7 @@ import java.beans.ConstructorProperties;
 public abstract class RequestMessage<V> extends ActorMessage implements FromMessage, IdMessage {
     private ActorRef from;
     private Object id;
+    private boolean call;
 
     /**
      * Constructs a new {@code RequestMessage}.
@@ -102,6 +103,20 @@ public abstract class RequestMessage<V> extends ActorMessage implements FromMess
      */
     void setFrom(ActorRef from) {
         this.from = from;
+    }
+
+    /**
+     * Called only by RequestReplyHelper
+     */
+    boolean isCall() {
+        return call;
+    }
+
+    /**
+     * Called only by RequestReplyHelper
+     */
+    void setCall(boolean call) {
+        this.call = call;
     }
 
     @Override

--- a/quasar-actors/src/main/java/co/paralleluniverse/actors/behaviors/ServerActor.java
+++ b/quasar-actors/src/main/java/co/paralleluniverse/actors/behaviors/ServerActor.java
@@ -297,6 +297,7 @@ public class ServerActor<CallMessage, V, CastMessage> extends BehaviorActor {
     public final void reply(ActorRef<?> to, Object id, V value) throws SuspendExecution {
         verifyInActor();
         ((ActorRef) to).send(new ValueResponseMessage<V>(id, value));
+        currentActor().unlink(to);
     }
 
     /**
@@ -315,6 +316,7 @@ public class ServerActor<CallMessage, V, CastMessage> extends BehaviorActor {
     public final void replyError(ActorRef<?> to, Object id, Throwable error) throws SuspendExecution {
         verifyInActor();
         ((ActorRef) to).send(new ErrorResponseMessage(id, error));
+        currentActor().unlink(to);
     }
 
     /**


### PR DESCRIPTION
Here's a possible fix based on `call`/`reply` coop. mediated by an additional `call` flag in `RequestMessage`.

Not sure how to include a reproducible test for this race condition internal to `RequestReplyHelper`, any ideas?