### PR TITLE
:bug: Fix #163

### DIFF
--- a/quasar-actors/src/main/java/co/paralleluniverse/actors/behaviors/RequestMessage.java
+++ b/quasar-actors/src/main/java/co/paralleluniverse/actors/behaviors/RequestMessage.java
@@ -26,6 +26,7 @@ import java.beans.ConstructorProperties;
 public abstract class RequestMessage<V> extends ActorMessage implements FromMessage, IdMessage {
     private ActorRef from;
     private Object id;
+    private boolean call;
 
     /**
      * Constructs a new {@code RequestMessage}.
@@ -102,6 +103,20 @@ public abstract class RequestMessage<V> extends ActorMessage implements FromMess
      */
     void setFrom(ActorRef from) {
         this.from = from;
+    }
+
+    /**
+     * Called only by RequestReplyHelper
+     */
+    boolean isCall() {
+        return call;
+    }
+
+    /**
+     * Called only by RequestReplyHelper
+     */
+    void setCall(boolean call) {
+        this.call = call;
     }
 
     @Override

--- a/quasar-actors/src/main/java/co/paralleluniverse/actors/behaviors/ServerActor.java
+++ b/quasar-actors/src/main/java/co/paralleluniverse/actors/behaviors/ServerActor.java
@@ -297,6 +297,7 @@ public class ServerActor<CallMessage, V, CastMessage> extends BehaviorActor {
     public final void reply(ActorRef<?> to, Object id, V value) throws SuspendExecution {
         verifyInActor();
         ((ActorRef) to).send(new ValueResponseMessage<V>(id, value));
+        currentActor().unlink(to);
     }
 
     /**
@@ -315,6 +316,7 @@ public class ServerActor<CallMessage, V, CastMessage> extends BehaviorActor {
     public final void replyError(ActorRef<?> to, Object id, Throwable error) throws SuspendExecution {
         verifyInActor();
         ((ActorRef) to).send(new ErrorResponseMessage(id, error));
+        currentActor().unlink(to);
     }
 
     /**

--- a/quasar-actors/src/test/java/co/paralleluniverse/actors/behaviors/SupervisorTest.java
+++ b/quasar-actors/src/test/java/co/paralleluniverse/actors/behaviors/SupervisorTest.java
@@ -443,40 +443,66 @@ public class SupervisorTest {
         AtomicInteger started = new AtomicInteger();
         AtomicInteger terminated = new AtomicInteger();
 
+        System.out.println("1");
+
         final Supervisor sup = new SupervisorActor(RestartStrategy.ALL_FOR_ONE,
                 new ChildSpec("actor1", ChildMode.PERMANENT, 5, 1, TimeUnit.SECONDS, 3, ActorSpec.of(Actor3.class, "actor1", started, terminated))).spawn();
 
         ActorRef<Integer> a;
 
+        System.out.println("2");
+
         a = getChild(sup, "actor1", 1000);
         a.send(3);
         a.send(4);
 
+        System.out.println("3");
+
         assertThat(LocalActor.<Integer>get(a), is(7));
+
+        System.out.println("4");
 
         a = getChild(sup, "actor1", 1000);
         a.send(70);
         a.send(80);
 
+        System.out.println("5");
+
         try {
             LocalActor.<Integer>get(a);
+            System.out.println("6");
             fail();
         } catch (ExecutionException e) {
         }
+
+        System.out.println("7");
 
         a = getChild(sup, "actor1", 1000);
         a.send(7);
         a.send(8);
 
+        System.out.println("8");
+
         assertThat(LocalActor.<Integer>get(a), is(15));
 
+        System.out.println("9");
+
         Thread.sleep(100); // give the actor time to start the GenServer
+
+        System.out.println("10");
 
         sup.shutdown();
         LocalActor.join(sup);
 
+        System.out.println("11");
+
         assertThat(started.get(), is(4));
+
+        System.out.println("12");
+
         assertThat(terminated.get(), is(4));
+
+        System.out.println("13");
     }
 
     static class Message1 {

--- a/quasar-actors/src/test/java/co/paralleluniverse/actors/behaviors/SupervisorTest.java
+++ b/quasar-actors/src/test/java/co/paralleluniverse/actors/behaviors/SupervisorTest.java
@@ -443,66 +443,41 @@ public class SupervisorTest {
         AtomicInteger started = new AtomicInteger();
         AtomicInteger terminated = new AtomicInteger();
 
-        System.out.println("1");
-
         final Supervisor sup = new SupervisorActor(RestartStrategy.ALL_FOR_ONE,
                 new ChildSpec("actor1", ChildMode.PERMANENT, 5, 1, TimeUnit.SECONDS, 3, ActorSpec.of(Actor3.class, "actor1", started, terminated))).spawn();
 
         ActorRef<Integer> a;
 
-        System.out.println("2");
-
         a = getChild(sup, "actor1", 1000);
         a.send(3);
         a.send(4);
 
-        System.out.println("3");
-
         assertThat(LocalActor.<Integer>get(a), is(7));
-
-        System.out.println("4");
 
         a = getChild(sup, "actor1", 1000);
         a.send(70);
         a.send(80);
 
-        System.out.println("5");
-
         try {
             LocalActor.<Integer>get(a);
-            System.out.println("6");
             fail();
         } catch (ExecutionException e) {
         }
-
-        System.out.println("7");
 
         a = getChild(sup, "actor1", 1000);
         a.send(7);
         a.send(8);
 
-        System.out.println("8");
-
         assertThat(LocalActor.<Integer>get(a), is(15));
 
-        System.out.println("9");
-
-        Thread.sleep(100); // give the actor time to start the GenServer
-
-        System.out.println("10");
+        Thread.sleep(300); // give the actor time to start the GenServer
 
         sup.shutdown();
         LocalActor.join(sup);
 
-        System.out.println("11");
-
         assertThat(started.get(), is(4));
 
-        System.out.println("12");
-
         assertThat(terminated.get(), is(4));
-
-        System.out.println("13");
     }
 
     static class Message1 {


### PR DESCRIPTION
Here's a possible fix based on `call`/`reply` cooperative `link`/`unlink` (resp.) via an additional `call` flag in `RequestMessage`.

The build was failing on JDK7 only on Travis (tried with the most recent JDK7 on 2 machines and with the same JDK7 version as Travis on the slower machine without being able to reproduce it) and it turns out one supervisor test had become too time-sensitive there, so increased slightly the timeout.

Not sure how to write a reproducible test for this race condition internal to `RequestReplyHelper`.