### PR TITLE
OpenTable initial attempt at Java 9 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
         classpath 'net.saliman:gradle-cobertura-plugin:2.3.1'
     }
 }
@@ -40,7 +40,7 @@ subprojects {
     ext.jdkVer = ext.java8 ? "8" : "7"
     ext.quasarJar = "${rootProject.projectDir}/quasar-core/build/libs/quasar-core-${version}${ext.java8 ? "-jdk8" : ""}.jar" // project(':quasar-core').jar.archivePath
 
-    ext.asmVer    = '5.2'
+    ext.asmVer    = '6.1.1'
     ext.kotlinVer = '1.1.3-2'
 
     if (!project.hasProperty("sonatypeUsername") || !project.hasProperty("sonatypePassword")) {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspendablesScanner.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/SuspendablesScanner.java
@@ -64,7 +64,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 public class SuspendablesScanner extends Task {
-    private static final int ASMAPI = Opcodes.ASM5;
+    private static final int ASMAPI = Opcodes.ASM6;
     //
     private final Map<String, MethodNode> methods = new HashMap<>();
     private final Map<String, ClassNode> classes = new HashMap<>();

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/TypeInterpreter.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/TypeInterpreter.java
@@ -47,6 +47,7 @@ class TypeInterpreter extends BasicInterpreter {
     private final MethodDatabase db;
 
     public TypeInterpreter(MethodDatabase db) {
+        super(ASM6);
         this.db = db;
     }
 


### PR DESCRIPTION
This PR represents a stab at Java 9 compatibility.  Our use case is currently limited—we're using only `quasar-core`, and even then, only channels (not fibers).

This patch is tested and works in the codebase in which we use this.  Unfortunately, though the project builds, and the functionality we need works properly, all of the unit tests now seem to fail.  A common error relates to exceeding a maximum stack size.  Perhaps given how dynamic everything is, some method call now inadvertently causes infinite recursion?

Anyway, it's not like this is ready for merge, but given [others][1] [clamoring][2] [for][3] [Java 9][4], we thought we'd at least share our hack so far.

[1]: https://github.com/puniverse/quasar/issues/278
[2]: https://github.com/puniverse/quasar/issues/253
[3]: https://github.com/puniverse/quasar/issues/233
[4]: https://github.com/puniverse/quasar/issues/295

    Failed test testSetRecordBeanGetDirect[3] [co.paralleluniverse.data.record.DynamicRecordTest] with exception: java.lang.VerifyError: Operand stack overflow
    Exception Details:
      Location:
        co/paralleluniverse/data/record/B$aAccessor$87b26b7.get(Ljava/lang/Object;)Z @0: aload_1
      Reason:
        Exceeded max stack size.
      Current Frame:
        bci: @0
        flags: { }
        locals: { 'co/paralleluniverse/data/record/B$aAccessor$87b26b7', 'java/lang/Object' }
        stack: { }
      Bytecode:
        0x0000000: 2bc0 000f b600 13ac                    
    
    java.lang.VerifyError: Operand stack overflow
    Exception Details:
      Location:
        co/paralleluniverse/data/record/B$aAccessor$87b26b7.get(Ljava/lang/Object;)Z @0: aload_1
      Reason:
        Exceeded max stack size.
      Current Frame:
        bci: @0
        flags: { }
        locals: { 'co/paralleluniverse/data/record/B$aAccessor$87b26b7', 'java/lang/Object' }
        stack: { }
      Bytecode:
        0x0000000: 2bc0 000f b600 13ac                    
    
            at java.lang.Class.getDeclaredConstructors0(Native Method)
            at java.lang.Class.privateGetDeclaredConstructors(Class.java:2671)
            at java.lang.Class.getConstructor0(Class.java:3075)
            at java.lang.Class.newInstance(Class.java:412)
            at co.paralleluniverse.data.record.DynamicGeneratedRecord.generateAccessor(DynamicGeneratedRecord.java:60)
            at co.paralleluniverse.data.record.RecordType$ClassInfo.<init>(RecordType.java:875)
            at co.paralleluniverse.data.record.RecordType$ClassInfo.<init>(RecordType.java:806)
            at co.paralleluniverse.data.record.RecordType$1.computeValue(RecordType.java:205)
            at co.paralleluniverse.data.record.RecordType$1.computeValue(RecordType.java:201)
            at java.lang.ClassValue.getFromHashMap(ClassValue.java:227)
            at java.lang.ClassValue.getFromBackup(ClassValue.java:209)
            at java.lang.ClassValue.get(ClassValue.java:115)
            at co.paralleluniverse.data.record.RecordType.wrap(RecordType.java:1085)
            at co.paralleluniverse.data.record.DynamicRecordTest.testSetRecordBeanGetDirect(DynamicRecordTest.java:645)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
            at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
            at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
            at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
            at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
            at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
            at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
            at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
            at org.junit.rules.RunRules.evaluate(RunRules.java:20)
            at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
            at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
            at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
            at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
            at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
            at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
            at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
            at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
            at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
            at org.junit.runners.Suite.runChild(Suite.java:128)
            at org.junit.runners.Suite.runChild(Suite.java:27)
            at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
            at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
            at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
            at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
            at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
            at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
            at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:116)
            at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:59)
            at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:39)
            at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:66)
            at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
            at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
            at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
            at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
            at com.sun.proxy.$Proxy3.processTestClass(Unknown Source)
            at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:109)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
            at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
            at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:146)
            at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:128)
            at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:404)
            at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
            at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
            at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
            at java.lang.Thread.run(Thread.java:748)
    
