### PR TITLE
Custom park and serialize without creating a new serializer

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/CustomFiberWriter.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/CustomFiberWriter.java
@@ -1,0 +1,10 @@
+package co.paralleluniverse.fibers;
+
+/**
+ * A callback used by {@link Fiber#parkAndCustomSerialize(CustomFiberWriter)}.
+ *
+ * @author Christian Sailer (christian.sailer@r3.com)
+ */
+public interface CustomFiberWriter {
+    void write(Fiber fiber);
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/CustomFiberWriterSerializer.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/CustomFiberWriterSerializer.java
@@ -1,0 +1,20 @@
+package co.paralleluniverse.fibers;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+/**
+ * @author Christian Sailer (christian.sailer@r3.com)
+ */
+public class CustomFiberWriterSerializer extends Serializer<CustomFiberWriter> {
+    @Override
+    public void write(Kryo kryo, Output output, CustomFiberWriter object) {
+    }
+
+    @Override
+    public CustomFiberWriter read(Kryo kryo, Input input, Class<CustomFiberWriter> type) {
+        return null;
+    }
+}

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -2009,7 +2009,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
         while (!park(SERIALIZER_BLOCKER, new ParkAction() {
             @Override
             public void run(Fiber f) {
-                f.record(1, "Fiber", "parkAndSerialize", "Serializing fiber %s", f);
+                f.record(1, "Fiber", "parkAndSerializeExternally", "Serializing fiber %s", f);
                 writer.run();
             }
         }));

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -2008,7 +2008,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
         while (!park(SERIALIZER_BLOCKER, new ParkAction() {
             @Override
             public void run(Fiber f) {
-                f.record(1, "Fiber", "parkAndSerializeExternally", "Serializing fiber %s", f);
+                f.record(1, "Fiber", "parkAndCustomSerialize", "Serializing fiber %s", f);
                 writer.run();
             }
         }));

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -1998,20 +1998,20 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
 
     /**
      * Parks the fiber and allows the given callback to serialize it, optimized for use cases where
-     * the callback object has all required information to serialize the fiber.
+     * the callback object has a custom way to obtain the required serializer (e.g. from a serializer pool)
      *
      * @param writer a callback that can serialize the fiber.
      * @throws SuspendExecution
      */
     @SuppressWarnings("empty-statement")
-    public static void parkAndCustomSerialize(final Runnable writer) throws SuspendExecution {
+    public static void parkAndCustomSerialize(final CustomFiberWriter writer) throws SuspendExecution {
         while (!park(SERIALIZER_BLOCKER, new ParkAction() {
             @Override
             public void run(Fiber f) {
                 f.record(1, "Fiber", "parkAndCustomSerialize", "Serializing fiber %s", f);
-                writer.run();
+                writer.write(f);
             }
-        }));
+        })) ;
     }
 
     /**
@@ -2074,6 +2074,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
         s.getKryo().addDefaultSerializer(Fiber.class, new FiberSerializer(includeThreadLocals));
         s.getKryo().addDefaultSerializer(ThreadLocal.class, new ThreadLocalSerializer());
         s.getKryo().addDefaultSerializer(FiberWriter.class, new FiberWriterSerializer());
+        s.getKryo().addDefaultSerializer(CustomFiberWriter.class, new CustomFiberWriterSerializer());
         s.getKryo().register(Fiber.class);
         s.getKryo().register(ThreadLocal.class);
         s.getKryo().register(InheritableThreadLocal.class);

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -1997,15 +1997,14 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
     }
 
     /**
-     * Parks the fiber and allows the given callback to serialize it.
+     * Parks the fiber and allows the given callback to serialize it, optimized for use cases where
+     * the callback object has all required information to serialize the fiber.
      *
      * @param writer a callback that can serialize the fiber.
      * @throws SuspendExecution
      */
     @SuppressWarnings("empty-statement")
     public static void parkAndCustomSerialize(final Runnable writer) throws SuspendExecution {
-//        if (writer == null)
-//            return; // should only happen during unparkSerialized
         while (!park(SERIALIZER_BLOCKER, new ParkAction() {
             @Override
             public void run(Fiber f) {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -2003,7 +2003,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
      * @throws SuspendExecution
      */
     @SuppressWarnings("empty-statement")
-    public static void parkAndSerialize(final Runnable writer) throws SuspendExecution {
+    public static void parkAndSerializeExternally(final Runnable writer) throws SuspendExecution {
 //        if (writer == null)
 //            return; // should only happen during unparkSerialized
         while (!park(SERIALIZER_BLOCKER, new ParkAction() {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -2003,7 +2003,7 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
      * @throws SuspendExecution
      */
     @SuppressWarnings("empty-statement")
-    public static void parkAndSerializeExternally(final Runnable writer) throws SuspendExecution {
+    public static void parkAndCustomSerialize(final Runnable writer) throws SuspendExecution {
 //        if (writer == null)
 //            return; // should only happen during unparkSerialized
         while (!park(SERIALIZER_BLOCKER, new ParkAction() {

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/Fiber.java
@@ -1997,6 +1997,25 @@ public class Fiber<V> extends Strand implements Joinable<V>, Serializable, Futur
     }
 
     /**
+     * Parks the fiber and allows the given callback to serialize it.
+     *
+     * @param writer a callback that can serialize the fiber.
+     * @throws SuspendExecution
+     */
+    @SuppressWarnings("empty-statement")
+    public static void parkAndSerialize(final Runnable writer) throws SuspendExecution {
+//        if (writer == null)
+//            return; // should only happen during unparkSerialized
+        while (!park(SERIALIZER_BLOCKER, new ParkAction() {
+            @Override
+            public void run(Fiber f) {
+                f.record(1, "Fiber", "parkAndSerialize", "Serializing fiber %s", f);
+                writer.run();
+            }
+        }));
+    }
+
+    /**
      * Deserializes a fiber from the given byte array and unparks it.
      *
      * @param serFiber  The byte array containing a fiber's serialized form.

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
@@ -35,7 +35,7 @@ public final class Classes {
         new BlockingMethod("java/lang/Object", "wait", "()V", "(J)V", "(JI)V"),};
 
     private static final Set<String> yieldMethods = new HashSet<>(Arrays.asList(new String[]{
-        "park", "yield", "parkAndUnpark", "yieldAndUnpark", "parkAndSerialize"
+        "park", "yield", "parkAndUnpark", "yieldAndUnpark", "parkAndSerialize", "parkAndSerializeExternally"
     }));
 
     // Don't load the classes

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
@@ -35,7 +35,7 @@ public final class Classes {
         new BlockingMethod("java/lang/Object", "wait", "()V", "(J)V", "(JI)V"),};
 
     private static final Set<String> yieldMethods = new HashSet<>(Arrays.asList(new String[]{
-            "park", "yield", "parkAndUnpark", "yieldAndUnpark", "parkAndSerialize", "parkAndCustomSerialize"
+        "park", "yield", "parkAndUnpark", "yieldAndUnpark", "parkAndSerialize", "parkAndCustomSerialize"
     }));
 
     // Don't load the classes

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/Classes.java
@@ -35,7 +35,7 @@ public final class Classes {
         new BlockingMethod("java/lang/Object", "wait", "()V", "(J)V", "(JI)V"),};
 
     private static final Set<String> yieldMethods = new HashSet<>(Arrays.asList(new String[]{
-        "park", "yield", "parkAndUnpark", "yieldAndUnpark", "parkAndSerialize", "parkAndSerializeExternally"
+            "park", "yield", "parkAndUnpark", "yieldAndUnpark", "parkAndSerialize", "parkAndCustomSerialize"
     }));
 
     // Don't load the classes


### PR DESCRIPTION
Corda uses `parkAndSerialize` with a custom FiberWriter that takes it serializer from a pool of pre-created serializers - hence it does not use the Kryo serializer that `parkAndSerialize()` creates for every single call.
Profiling has shown that creating a Kryo serializer has a non-trivial cost in terms of CPU cycles, and as it does not get used in our case, this effort is completely wasted. Therefore, I have created a small patch that allows to parkAndSerialize with a custom writer without creating a new serializer.