### PR TITLE
Fix ScheduledSingleThreadExecutor.awaitTermination exception for nano time calculation error

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ScheduledSingleThreadExecutor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/concurrent/util/ScheduledSingleThreadExecutor.java
@@ -710,7 +710,7 @@ public class ScheduledSingleThreadExecutor extends AbstractExecutorService imple
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         long nanos = unit.toNanos(timeout);
         long millis = TimeUnit.MILLISECONDS.convert(nanos, TimeUnit.NANOSECONDS);
-        worker.join(millis, (int) (nanos - millis));
+        worker.join(millis, (int) (nanos - millis * 1000000));
         return !worker.isAlive();
     }
 

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/JMXFibersMonitor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/JMXFibersMonitor.java
@@ -217,6 +217,9 @@ class JMXFibersMonitor extends StandardEmitterMBean implements FibersMonitor, No
     @Override
     public Map<String, String> getRunawayFibers() {
         Map<String, String> map = new HashMap<>();
+	if (problemFibers == null) {
+	    return map;
+	}
         for (Map.Entry<Fiber, StackTraceElement[]> e : problemFibers.entrySet())
             map.put(e.getKey().toString(), Strand.toString(e.getValue()));
         return map;

--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/JMXFibersMonitor.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/JMXFibersMonitor.java
@@ -217,9 +217,9 @@ class JMXFibersMonitor extends StandardEmitterMBean implements FibersMonitor, No
     @Override
     public Map<String, String> getRunawayFibers() {
         Map<String, String> map = new HashMap<>();
-	if (problemFibers == null) {
-	    return map;
-	}
+        if (problemFibers == null) {
+            return map;
+        }
         for (Map.Entry<Fiber, StackTraceElement[]> e : problemFibers.entrySet())
             map.put(e.getKey().toString(), Strand.toString(e.getValue()));
         return map;


### PR DESCRIPTION
**DESCRIPTION**
ScheduledSingleThreadExecutor.awaitTermination crashes for Thread.join() second parameter nanos out of range, which is calculated wrong in awaitTermination ().
`worker.join(millis, (int) (nanos - millis));`

By the way, nobody ever calls this function? Does it mean we no need to await for a fiber ?