### PR TITLE
added workaround for https://youtrack.jetbrains.com/issue/KT-30289

### DIFF
--- a/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
+++ b/quasar-core/src/main/java/co/paralleluniverse/fibers/instrument/MethodDatabase.java
@@ -449,7 +449,7 @@ public class MethodDatabase {
 
     public enum SuspendableType {
         NON_SUSPENDABLE, SUSPENDABLE_SUPER, SUSPENDABLE
-    };
+    }
 
     public static final class ClassEntry {
         private final HashMap<String, SuspendableType> methods;


### PR DESCRIPTION
this should fix quasar issue with Kotlin 1.3, the idea is to instrument any static synthetic method whose name ends with `$default` if it comes after a suspendable method with the same name (except for the $default suffix) and a similar signature (more details about it will follow). 

I did some manual testing and it seems to work, it relies on the fact that the Kotlin compiler writes the `$default` methods only after their base counterparts (which could be problematic since, although this is [the current behavior](https://github.com/JetBrains/kotlin/blob/master/compiler/backend/src/org/jetbrains/kotlin/codegen/FunctionCodegen.java#L133-L139), there is no guarantee around its stability).